### PR TITLE
Revert "feat: rename to <toolName>-pact-adapter for consistency (#37)"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a bug with msw-pact-adapter
+about: Report a bug with pact-msw-adapter
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Request a new feature (or a modification to an existing feature) for msw-pact-adapter
+about: Request a new feature (or a modification to an existing feature) for pact-msw-adapter
 title: ''
 labels: enhancement
 assignees: ''

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Thank you for making a pull request! -->
 
-<!-- msw-pact-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->
+<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->
 
 <!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,20 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* release as msw-pact-adapter ([#36](https://github.com/pactflow/msw-pact-adapter/issues/36)) ([1850d33](https://github.com/pactflow/msw-pact-adapter/commit/1850d330fdb8625012079a26284ff229a52c075d))
+* release as pact-msw-adapter ([#36](https://github.com/pactflow/pact-msw-adapter/issues/36)) ([1850d33](https://github.com/pactflow/pact-msw-adapter/commit/1850d330fdb8625012079a26284ff229a52c075d))
 
-### [0.9.2](https://github.com/pactflow/msw-pact-adapter/compare/v0.8.4...v0.9.2) (2022-03-08)
-
-
-### Features
-
-* release 0.9.1 ([8655ebe](https://github.com/pactflow/msw-pact-adapter/commit/8655ebec99822982a01a4e5ca9b6377fcf212280))
-
-### [0.8.4](https://github.com/pactflow/msw-pact-adapter/compare/v0.8.2...v0.8.4) (2022-03-07)
+### [0.9.2](https://github.com/pactflow/pact-msw-adapter/compare/v0.8.4...v0.9.2) (2022-03-08)
 
 
 ### Features
 
-* setup ci and release flow ([5a1e05d](https://github.com/pactflow/msw-pact-adapter/commit/5a1e05d1356a53996b845df7d52c0cbf4eb27e35))
+* release 0.9.1 ([8655ebe](https://github.com/pactflow/pact-msw-adapter/commit/8655ebec99822982a01a4e5ca9b6377fcf212280))
+
+### [0.8.4](https://github.com/pactflow/pact-msw-adapter/compare/v0.8.2...v0.8.4) (2022-03-07)
+
+
+### Features
+
+* setup ci and release flow ([5a1e05d](https://github.com/pactflow/pact-msw-adapter/commit/5a1e05d1356a53996b845df7d52c0cbf4eb27e35))
 
 ### 0.8.2 (2022-03-07)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# msw-pact-adapter
+# pact-msw-adapter
 
 Generate pact contracts from the recorded mock service worker interactions.
 
@@ -7,25 +7,25 @@ Check out this issue for the initial proposal on msw's repo https://github.com/m
 ##  Getting started
 
 ```
-npm install @pactflow/msw-pact-adapter --save-dev 
+npm install @pactflow/pact-msw-adapter --save-dev 
 ```
 or yarn
 ```
-yarn add -D @pactflow/msw-pact-adapter 
+yarn add -D @pactflow/pact-msw-adapter 
 ```
 
 MSW provides a `setupServer` for node environments and `setupWorker` for browser based environment
 
 ```js
 import { setupServer } from "msw/node";
-import { setupMswPactAdapter } from "@pactflow/msw-pact-adapter";
+import { setupPactMswAdapter } from "@pactflow/pact-msw-adapter";
 ```
 
 For browser based enviromnents
 
 ```js
 import { setupWorker } from "msw";
-import { setupMswPactAdapter } from "@pactflow/msw-pact-adapter";
+import { setupPactMswAdapter } from "@pactflow/pact-msw-adapter";
 ```
 
 See [./src/pactFromMswServer.msw.spec.ts](./src/pactFromMswServer.msw.spec.ts) for an example testing an API client, used in a react application
@@ -35,10 +35,10 @@ This test will generate pacts, which can be found in the `./msw_generated_pacts`
 ## How to use
 
 Let's start by listing it's methods:
-- `setupMswPactAdapter`: Generates an msw-pact-adapter instance. It also allows for several options on the adapter.
+- `setupPactMswAdapter`: Generates an pact-msw-adapter instance. It also allows for several options on the adapter.
 - `newTest`: Tells the adapter a new test is about to start. This is used for validating msw calls.
 - `verifyTest`: Waits for all pending network calls to finish or timeout, and asserts that all these calls started and finished on the same test without unexpected errors, and that there were no calls to included urls which aren't handled by msw.
-- `clear`: Resets all msw-pact-adapter's internal states, same effect as generating a new msw-pact-adapter instance.
+- `clear`: Resets all pact-msw-adapter's internal states, same effect as generating a new pact-msw-adapter instance.
 - `writeToFile`: Dumps all the recorded msw calls to pact files, generating one pact file for each consumer-provider call. For browser environments, it requires a custom file writter as argument.
 
 
@@ -55,11 +55,11 @@ Let's start by listing it's methods:
 | includeUrl | `false` | `string[]` | | inclusive filters for network calls |
 | excludeUrl | `false` | `string[]` | | exclusive filters for network calls |
 | excludeHeaders | `false` | `string[]` | | exclude generated headers from being written to request/response objects in pact file |
-| debug | `false` | `boolean` | `false` | prints verbose information about msw-pact-adapter events |
+| debug | `false` | `boolean` | `false` | prints verbose information about pact-msw-adapter events |
 
 ## Route filtering
 
-By default msw-pact-adapter will try to record an interaction for every single network call, including external dependencies, fonts or static resources. This is why we’re implementing a route filtering mechanism to include only relevant paths in our pact files.
+By default pact-msw-adapter will try to record an interaction for every single network call, including external dependencies, fonts or static resources. This is why we’re implementing a route filtering mechanism to include only relevant paths in our pact files.
 
 This mechanism has three layers, in order of priority:
 - `excludeUrl`: All paths containing any of the strings present in this array will be ignored.
@@ -70,7 +70,7 @@ The first two layers can be skipped by setting it’s value to `undefined`. The 
 
 ## Header filtering
 
-By default msw-pact-adapter captures and serialises all request and response headers captured, in the generated pact file.
+By default pact-msw-adapter captures and serialises all request and response headers captured, in the generated pact file.
 
 You may wish to exclude these on a global basis.
 
@@ -79,7 +79,7 @@ This mechanism currently has a layer
 
 ## Custom file writers
 
-The adapter uses by default node’s filesystem to write pact files to disk. This makes it incompatible with browser environments where `fs` is not available. To overcome this, `msw-pact-adapter` allows for defining custom functions for writting files to disk.
+The adapter uses by default node’s filesystem to write pact files to disk. This makes it incompatible with browser environments where `fs` is not available. To overcome this, `pact-msw-adapter` allows for defining custom functions for writting files to disk.
 
 ```js
 writeToFile(writer?: (path: string, data: object) => void): Promise<void>
@@ -93,30 +93,30 @@ The `data` field consists of a javascript object containing a pact file (check t
 
 ## Pact files generation
 
-`msw-pact-adapter` will dump all the recorded requests into pact files when `writeToFile` is called.
+`pact-msw-adapter` will dump all the recorded requests into pact files when `writeToFile` is called.
 
-A recorded request is a request which has started and been successfully mocked by msw since msw-pact-adapter has been instantiated or cleared. This can include duplicated requests and does not distinguishes between different test runs.
+A recorded request is a request which has started and been successfully mocked by msw since pact-msw-adapter has been instantiated or cleared. This can include duplicated requests and does not distinguishes between different test runs.
 
 Each time `writeToFile` is run, it will generate one pact file for every consumer-provider pair. In practice, consumers are fixed, making it to generate one pact file per provider.
 
-In order to do this, `msw-pact-adapter` uses the providers map to asociate a request with a provider. The providers map is iterated in order and each request is associated with exactly one provider.
+In order to do this, `pact-msw-adapter` uses the providers map to asociate a request with a provider. The providers map is iterated in order and each request is associated with exactly one provider.
 
-Once this association is done, `msw-pact-adapter` will translate each request to a pact interaction and group these interactions on pact files by provider.
+Once this association is done, `pact-msw-adapter` will translate each request to a pact interaction and group these interactions on pact files by provider.
 
 
 <details>
-  <summary>msw-pact-adapter implementation</summary>
+  <summary>pact-msw-adapter implementation</summary>
     <br>
 
 ```js
-import { setupMswPactAdapter } from '@pactflow/msw-pact-adapter';
+import { setupPactMswAdapter } from '@pactflow/pact-msw-adapter';
 
-let mswPactAdapter: any = undefined;
+let pactMswAdapter: any = undefined;
 
 beforeEach(async () => {
-    if (!mswPactAdapter) {
+    if (!pactMswAdapter) {
         cy.window().then(window => {
-            mswPactAdapter = setupMswPactAdapter({
+            pactMswAdapter = setupPactMswAdapter({
                 worker: window.msw.worker,
                 options: {
                     consumer: 'web-ea',
@@ -129,17 +129,17 @@ beforeEach(async () => {
                     // debug: true
                 },
               });
-            mswPactAdapter.newTest();
+            pactMswAdapter.newTest();
         });
     } else {
-        mswPactAdapter.newTest();
+        pactMswAdapter.newTest();
     }
 });
 afterEach(async () => {
-    if (!mswPactAdapter) return;
+    if (!pactMswAdapter) return;
     
     try {
-        await mswPactAdapter.verifyTest();
+        await pactMswAdapter.verifyTest();
     } catch (err) {
         // cypress doesn't like errors on hooks...
         if (process.env.NODE_ENV !== 'production') {
@@ -153,10 +153,10 @@ afterEach(async () => {
     }
 });
 after(async () => {
-    if (!mswPactAdapter) return;
+    if (!pactMswAdapter) return;
 
-    await mswPactAdapter.writeToFile((path: string, data: object) => cy.writeFile(path, data));
-    mswPactAdapter.clear();
+    await pactMswAdapter.writeToFile((path: string, data: object) => cy.writeFile(path, data));
+    pactMswAdapter.clear();
 });
 ```
 </details>
@@ -200,6 +200,6 @@ Here, `matchingRules` represent the assertions of the expectation, while `body`,
 
 Made possible by these awesome people! You are welcome to contribute too!
 
-![Repo Contributors](https://contrib.rocks/image?repo=pactflow/msw-pact-adapter)
+![Repo Contributors](https://contrib.rocks/image?repo=pactflow/pact-msw-adapter)
 
 Special thanks to [Juan Cruz](https://github.com/IJuanI) for being an early adopter and improving the experience!

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@pactflow/msw-pact-adapter",
+  "name": "@pactflow/pact-msw-adapter",
   "version": "0.10.3",
-  "main": "./dist/mswPactAdapter.js",
+  "main": "./dist/pactMswAdapter.js",
   "keywords": [
     "pact",
     "msw",
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pactflow/msw-pact-adapter.git"
+    "url": "git+https://github.com/pactflow/pact-msw-adapter.git"
   },
   "author": {
     "name": "Yousaf Nabi",

--- a/scripts/ci/lib/publish.sh
+++ b/scripts/ci/lib/publish.sh
@@ -12,6 +12,6 @@ echo "--> Preparing npmrc file"
 echo "--> Releasing version ${VERSION}"
 
 echo "--> Releasing artifacts"
-echo "    Publishing msw-pact-adapter@${VERSION}..."
+echo "    Publishing pact-msw-adapter@${VERSION}..."
 npm publish --access public --tag latest
 echo "    done!"

--- a/src/convertMswMatchToPact.msw.spec.ts
+++ b/src/convertMswMatchToPact.msw.spec.ts
@@ -1,5 +1,5 @@
 import { convertMswMatchToPact } from "./convertMswMatchToPact";
-import { MswMatch, PactFile } from "./mswPactAdapter";
+import { MswMatch, PactFile } from "./pactMswAdapter";
 import { Headers } from 'headers-polyfill';
 
 const generatedPact:PactFile = {

--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -1,4 +1,4 @@
-import { PactFile, MswMatch } from './mswPactAdapter';
+import { PactFile, MswMatch } from './pactMswAdapter';
 import { omit } from 'lodash';
 import { HeadersObject, Headers } from 'headers-polyfill';
 export const convertMswMatchToPact = ({

--- a/src/pactFromMswServer.msw.spec.ts
+++ b/src/pactFromMswServer.msw.spec.ts
@@ -1,10 +1,10 @@
 import API from "../examples/react/src/api";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { PactFile, setupMswPactAdapter } from "./mswPactAdapter";
+import { PactFile, setupPactMswAdapter } from "./pactMswAdapter";
 
 const server = setupServer();
-const mswPactAdapter = setupMswPactAdapter({
+const pactMswAdapter = setupPactMswAdapter({
   server,
   options: {
     consumer: "testConsumer", providers: { ['testProvider']: ['products'],['testProvider2']: ['/product/10'] },
@@ -21,17 +21,17 @@ describe("API - With MSW mock generating a pact", () => {
   });
 
   beforeEach(async () => {
-    mswPactAdapter.newTest();
+    pactMswAdapter.newTest();
   });
 
   afterEach(async () => {
-    mswPactAdapter.verifyTest();
+    pactMswAdapter.verifyTest();
     server.resetHandlers();
   });
 
   afterAll(async () => {
-    await mswPactAdapter.writeToFile(); // writes the pacts to a file
-    mswPactAdapter.clear();
+    await pactMswAdapter.writeToFile(); // writes the pacts to a file
+    pactMswAdapter.clear();
     server.close();
   });
 
@@ -77,7 +77,7 @@ describe("API - With MSW mock generating a pact", () => {
 
   test("creates pact files", async () => {
     let pactResults: PactFile[] = []
-    await mswPactAdapter.writeToFile((path, data) => { pactResults.push(data as PactFile) }); // writes the pacts to a file
+    await pactMswAdapter.writeToFile((path, data) => { pactResults.push(data as PactFile) }); // writes the pacts to a file
     expect(pactResults.length).toEqual(2)
     expect(pactResults[0].consumer.name).toEqual('testConsumer')
     expect(pactResults[0].provider.name).toEqual('testProvider')

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,8 @@
-import { MswPactAdapterOptions } from "../mswPactAdapter";
+import { PactMswAdapterOptions } from "../pactMswAdapter";
 var path = require("path");
 let fs: any; // dynamic import
 
-const logPrefix = '[msw-pact-adapter]';
+const logPrefix = '[pact-msw-adapter]';
 const logColors = {
   log: 'forestgreen',
   warning: 'gold',
@@ -59,7 +59,7 @@ const writeData2File = (filePath: string, data: Object) => {
   }
 };
 
-const checkUrlFilters = (urlString: string, options: MswPactAdapterOptions) => {
+const checkUrlFilters = (urlString: string, options: PactMswAdapterOptions) => {
   const providerFilter = Object.values(options.providers)
     ?.some(validPaths => validPaths.some(path => urlString.includes(path)));
   const includeFilter = !options.includeUrl || options.includeUrl.some(inc => urlString.includes(inc));
@@ -75,7 +75,7 @@ const checkUrlFilters = (urlString: string, options: MswPactAdapterOptions) => {
 const addTimeout = async<T>(promise: Promise<T>, label: string, timeout: number) => {
   const asyncTimeout = new Promise<void>((_, reject) => {
     setTimeout(() => {
-      reject(new Error(`[msw-pact-adapter] ${label} timed out after ${timeout}ms`));
+      reject(new Error(`[pact-msw-adapter] ${label} timed out after ${timeout}ms`));
     }, timeout);
   });
 


### PR DESCRIPTION
For cypress, we have published `@pactflow/pact-cypress-adapter` so `pact-<toolName>-adapter`

The repo should be renamed for consistency from https://github.com/pactflow/cypress-pact-adapter to https://github.com/pactflow/pact-cypress-adapter

This revert will rename back to `pact-msw-adapter`. 

Naming things is hard 😂 best to get it right up front!