### PR TITLE
feat: add query to request in the pact file

### DIFF
--- a/examples/react/src/api.js
+++ b/examples/react/src/api.js
@@ -35,8 +35,9 @@ export class API {
             .then(r => r.data);
     }
 
-    async getProduct(id) {
+    async getProduct(id, params) {
         return axios.get(this.withPath("/product/" + id), {
+            params,
             headers: {
                 "Authorization": this.generateAuthToken()
             }

--- a/src/convertMswMatchToPact.msw.spec.ts
+++ b/src/convertMswMatchToPact.msw.spec.ts
@@ -17,6 +17,7 @@ const generatedPact:PactFile = {
           accept: "application/json, text/plain, */*",
           authorization: "Bearer 2022-03-01T19:36:18.277Z",
         },
+        query: 'sort=asc'
       },
       response: {
         status: 200,
@@ -32,7 +33,7 @@ const sampleMatch: MswMatch[] = [
   {
     request: {
       id: 'de5eefb0-c451-4ae2-9695-e02626f00ca7',
-      url: new URL('http://localhost:8081/products'),
+      url: new URL('http://localhost:8081/products?sort=asc'),
       method: 'GET',
       body: undefined,
       headers: new Headers({

--- a/src/convertMswMatchToPact.msw.spec.ts
+++ b/src/convertMswMatchToPact.msw.spec.ts
@@ -2,12 +2,30 @@ import { convertMswMatchToPact } from "./convertMswMatchToPact";
 import { MswMatch, PactFile } from "./pactMswAdapter";
 import { Headers } from 'headers-utils';
 
-const generatedPact:PactFile = {
+const generatedPact: PactFile = {
   consumer: { name: "interaction.consumer.name" },
   provider: { name: "interaction.provider.name" },
   interactions: [
     {
       description: "de5eefb0-c451-4ae2-9695-e02626f00ca7",
+      providerState: "",
+      request: {
+        method: "GET",
+        path: "/products",
+        body: undefined,
+        headers: {
+          accept: "application/json, text/plain, */*",
+          authorization: "Bearer 2022-03-01T19:36:18.277Z",
+        }
+      },
+      response: {
+        status: 200,
+        body: [{ id: "09", type: "CREDIT_CARD", name: "Gem Visa" }],
+        headers: { "x-powered-by": "msw", "content-type": "application/json" },
+      },
+    },
+    {
+      description: "073d6de0-e1ac-11ec-8fea-0242ac120002",
       providerState: "",
       request: {
         method: "GET",
@@ -33,6 +51,44 @@ const sampleMatch: MswMatch[] = [
   {
     request: {
       id: 'de5eefb0-c451-4ae2-9695-e02626f00ca7',
+      url: new URL('http://localhost:8081/products'),
+      method: 'GET',
+      body: undefined,
+      headers: new Headers({
+        accept: 'application/json, text/plain, */*',
+        authorization: 'Bearer 2022-03-01T19:36:18.277Z',
+        'user-agent': 'axios/0.21.1',
+        host: 'localhost:8081',
+        'content-type': 'application/json'
+      }),
+      cookies: {},
+      redirect: 'manual',
+      referrer: '',
+      keepalive: false,
+      cache: 'default',
+      mode: 'cors',
+      referrerPolicy: 'no-referrer',
+      integrity: '',
+      destination: 'document',
+      bodyUsed: false,
+      credentials: 'same-origin'
+    },
+    response: {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({
+        'x-powered-by': 'msw',
+        'content-type': 'application/json'
+      }),
+      body: JSON.stringify([
+        { id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }
+      ])
+    },
+    body: JSON.stringify([{ id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }])
+  },
+  {
+    request: {
+      id: '073d6de0-e1ac-11ec-8fea-0242ac120002',
       url: new URL('http://localhost:8081/products?sort=asc'),
       method: 'GET',
       body: undefined,
@@ -69,6 +125,7 @@ const sampleMatch: MswMatch[] = [
     body: JSON.stringify([{ id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }])
   }
 ];
+
 describe("writes an msw req/res to a pact", () => {
   it("should convert an msw server match to a pact", async () => {
     expect(
@@ -80,4 +137,3 @@ describe("writes an msw req/res to a pact", () => {
     ).toMatchObject(generatedPact);
   });
 });
-

--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -24,7 +24,8 @@ export const convertMswMatchToPact =  ({
           headers: headers?.excludeHeaders
             ? omit(match.request.headers['_headers'], headers.excludeHeaders)
             : match.request.headers['_headers'],
-          body: match.request.body || undefined
+          body: match.request.body || undefined,
+          query: match.request.url.search ? match.request.url.search.split('?')[1] : undefined
         },
         response: {
           status: match.response.status,

--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -1,6 +1,6 @@
 import { PactFile, MswMatch } from "./pactMswAdapter";
 import { omit } from "lodash";
-export const convertMswMatchToPact =  ({
+export const convertMswMatchToPact = ({
   consumer,
   provider,
   matches,
@@ -14,40 +14,39 @@ export const convertMswMatchToPact =  ({
   const pactFile: PactFile = {
     consumer: { name: consumer },
     provider: { name: provider },
-    interactions:  matches.map(  (match) => {
-      return {
-        description: match.request.id,
-        providerState: '',
-        request: {
-          method: match.request.method,
-          path: match.request.url.pathname,
-          headers: headers?.excludeHeaders
-            ? omit(match.request.headers['_headers'], headers.excludeHeaders)
-            : match.request.headers['_headers'],
-          body: match.request.body || undefined,
-          query: match.request.url.search ? match.request.url.search.split('?')[1] : undefined
-        },
-        response: {
-          status: match.response.status,
-          headers: headers?.excludeHeaders
-            ? omit(
-                Object.fromEntries(match.response.headers.entries()),
-                headers.excludeHeaders
-              )
-            : Object.fromEntries(match.response.headers.entries()),
-          body: match.body
-            ? match.response.headers.get('content-type')?.includes('json')
-              ? JSON.parse(match.body)
-              : match.body
-            : undefined
-        }
-      };
-    }),
+    interactions: matches.map(match => ({
+      description: match.request.id,
+      providerState: '',
+      request: {
+        method: match.request.method,
+        path: match.request.url.pathname,
+        headers: headers?.excludeHeaders
+          ? omit(match.request.headers['_headers'], headers.excludeHeaders)
+          : match.request.headers['_headers'],
+        body: match.request.body || undefined,
+        query: match.request.url.search ? match.request.url.search.split('?')[1] : undefined
+      },
+      response: {
+        status: match.response.status,
+        headers: headers?.excludeHeaders
+          ? omit(
+              Object.fromEntries(match.response.headers.entries()),
+              headers.excludeHeaders
+            )
+          : Object.fromEntries(match.response.headers.entries()),
+        body: match.body
+          ? match.response.headers.get('content-type')?.includes('json')
+            ? JSON.parse(match.body)
+            : match.body
+          : undefined
+      }
+    })),
     metadata: {
       pactSpecification: {
         version: "2.0.0",
       },
     },
   };
+
   return pactFile;
 };

--- a/src/pactFromMswServer.msw.spec.ts
+++ b/src/pactFromMswServer.msw.spec.ts
@@ -88,6 +88,29 @@ describe("API - With MSW mock generating a pact", () => {
     expect(respProduct).toEqual(product);
   });
 
+  test("get product ID 10 with visibility hidden", async () => {
+    const product = {
+      id: "10",
+      type: "CREDIT_CARD",
+      name: "28 Degrees"
+    };
+    const hiddenVisibilityProduct = {
+      ...product,
+      visibility: "hidden"
+    };
+    server.use(
+      rest.get(API.url + "/product/10", (req, res, ctx) => {
+        const visibility = req.url.searchParams.get('visibility');
+        const response = visibility === 'hidden' ? hiddenVisibilityProduct : product;
+
+        return res(ctx.status(200), ctx.json(response));
+      })
+    );
+
+    const respProduct = await API.getProduct("10", {visibility: "hidden"});
+    expect(respProduct).toEqual(hiddenVisibilityProduct);
+  });
+
   test("unhandled route", async () => {
     await expect(API.getProduct("11")).rejects.toThrow(
       /^connect ECONNREFUSED (127.0.0.1|::1):8081$/

--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -376,7 +376,7 @@ export interface PactInteraction {
     path: string;
     headers: any;
     body: DefaultRequestBody;
-    query: any;
+    query?: string;
   };
   response: {
     status: number;

--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -376,6 +376,7 @@ export interface PactInteraction {
     path: string;
     headers: any;
     body: DefaultRequestBody;
+    query: any;
   };
   response: {
     status: number;


### PR DESCRIPTION
<!-- Thank you for making a pull request! -->

<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

<!-- _Please describe what this PR is for, or link the issue that this PR fixes_ -->

When any request with a **query string** is intercepted in a route handled by `pact-msw-adapter`, the Pact file should be written with the property `query` inside the [`request` object](https://github.com/pactflow/pact-msw-adapter/blob/main/src/convertMswMatchToPact.ts#L21).

This PR fixes the issue: https://github.com/pactflow/pact-msw-adapter/issues/45

<!-- _You may add as much or as little context as you like here, whatever you think is right_ -->

<!-- _Thanks again!_ -->
