### PR TITLE
feat: Add client name/version into pact file

### DIFF
--- a/src/convertMswMatchToPact.msw.spec.ts
+++ b/src/convertMswMatchToPact.msw.spec.ts
@@ -1,6 +1,7 @@
 import { convertMswMatchToPact } from "./convertMswMatchToPact";
 import { MswMatch, PactFile } from "./pactMswAdapter";
-import { Headers } from 'headers-utils';
+import { Headers } from "headers-utils";
+const pjson = require("../package.json");
 
 const generatedPact: PactFile = {
   consumer: { name: "interaction.consumer.name" },
@@ -16,7 +17,7 @@ const generatedPact: PactFile = {
         headers: {
           accept: "application/json, text/plain, */*",
           authorization: "Bearer 2022-03-01T19:36:18.277Z",
-        }
+        },
       },
       response: {
         status: 200,
@@ -35,7 +36,7 @@ const generatedPact: PactFile = {
           accept: "application/json, text/plain, */*",
           authorization: "Bearer 2022-03-01T19:36:18.277Z",
         },
-        query: 'sort=asc'
+        query: "sort=asc",
       },
       response: {
         status: 200,
@@ -44,86 +45,89 @@ const generatedPact: PactFile = {
       },
     },
   ],
-  metadata: { pactSpecification: { version: "2.0.0" } },
+  metadata: {
+    pactSpecification: { version: "2.0.0" },
+    client: { name: "pact-msw-adapter", version: pjson.version },
+  },
 };
 
 const sampleMatch: MswMatch[] = [
   {
     request: {
-      id: 'de5eefb0-c451-4ae2-9695-e02626f00ca7',
-      url: new URL('http://localhost:8081/products'),
-      method: 'GET',
+      id: "de5eefb0-c451-4ae2-9695-e02626f00ca7",
+      url: new URL("http://localhost:8081/products"),
+      method: "GET",
       body: undefined,
       headers: new Headers({
-        accept: 'application/json, text/plain, */*',
-        authorization: 'Bearer 2022-03-01T19:36:18.277Z',
-        'user-agent': 'axios/0.21.1',
-        host: 'localhost:8081',
-        'content-type': 'application/json'
+        accept: "application/json, text/plain, */*",
+        authorization: "Bearer 2022-03-01T19:36:18.277Z",
+        "user-agent": "axios/0.21.1",
+        host: "localhost:8081",
+        "content-type": "application/json",
       }),
       cookies: {},
-      redirect: 'manual',
-      referrer: '',
+      redirect: "manual",
+      referrer: "",
       keepalive: false,
-      cache: 'default',
-      mode: 'cors',
-      referrerPolicy: 'no-referrer',
-      integrity: '',
-      destination: 'document',
+      cache: "default",
+      mode: "cors",
+      referrerPolicy: "no-referrer",
+      integrity: "",
+      destination: "document",
       bodyUsed: false,
-      credentials: 'same-origin'
+      credentials: "same-origin",
     },
     response: {
       status: 200,
-      statusText: 'OK',
+      statusText: "OK",
       headers: new Headers({
-        'x-powered-by': 'msw',
-        'content-type': 'application/json'
+        "x-powered-by": "msw",
+        "content-type": "application/json",
       }),
       body: JSON.stringify([
-        { id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }
-      ])
+        { id: "09", type: "CREDIT_CARD", name: "Gem Visa" },
+      ]),
     },
-    body: JSON.stringify([{ id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }])
+    body: JSON.stringify([{ id: "09", type: "CREDIT_CARD", name: "Gem Visa" }]),
   },
   {
     request: {
-      id: '073d6de0-e1ac-11ec-8fea-0242ac120002',
-      url: new URL('http://localhost:8081/products?sort=asc'),
-      method: 'GET',
+      id: "073d6de0-e1ac-11ec-8fea-0242ac120002",
+      url: new URL("http://localhost:8081/products?sort=asc"),
+      method: "GET",
       body: undefined,
       headers: new Headers({
-        accept: 'application/json, text/plain, */*',
-        authorization: 'Bearer 2022-03-01T19:36:18.277Z',
-        'user-agent': 'axios/0.21.1',
-        host: 'localhost:8081',
-        'content-type': 'application/json'
+        accept: "application/json, text/plain, */*",
+        authorization: "Bearer 2022-03-01T19:36:18.277Z",
+        "user-agent": "axios/0.21.1",
+        host: "localhost:8081",
+        "content-type": "application/json",
       }),
       cookies: {},
-      redirect: 'manual',
-      referrer: '',
+      redirect: "manual",
+      referrer: "",
       keepalive: false,
-      cache: 'default',
-      mode: 'cors',
-      referrerPolicy: 'no-referrer',
-      integrity: '',
-      destination: 'document',
+      cache: "default",
+      mode: "cors",
+      referrerPolicy: "no-referrer",
+      integrity: "",
+      destination: "document",
       bodyUsed: false,
-      credentials: 'same-origin'
+      credentials: "same-origin",
     },
     response: {
       status: 200,
-      statusText: 'OK',
+      statusText: "OK",
       headers: new Headers({
-        'x-powered-by': 'msw',
-        'content-type': 'application/json'
+        "x-powered-by": "msw",
+        "content-type": "application/json",
       }),
       body: JSON.stringify([
-        { id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }
-      ])
+        { id: "09", type: "CREDIT_CARD", name: "Gem Visa" },
+      ]),
     },
-    body: JSON.stringify([{ id: '09', type: 'CREDIT_CARD', name: 'Gem Visa' }])
-  }
+    body: JSON.stringify([{ id: "09", type: "CREDIT_CARD", name: "Gem Visa" }]),
+  },
 ];
 
 describe("writes an msw req/res to a pact", () => {
@@ -131,8 +135,8 @@ describe("writes an msw req/res to a pact", () => {
     expect(
       convertMswMatchToPact({
         matches: sampleMatch as any,
-        consumer: 'interaction.consumer.name',
-        provider: 'interaction.provider.name',
+        consumer: "interaction.consumer.name",
+        provider: "interaction.provider.name",
       })
     ).toMatchObject(generatedPact);
   });

--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -1,5 +1,6 @@
 import { PactFile, MswMatch } from "./pactMswAdapter";
 import { omit } from "lodash";
+const pjson = require("../package.json");
 export const convertMswMatchToPact = ({
   consumer,
   provider,
@@ -14,17 +15,22 @@ export const convertMswMatchToPact = ({
   const pactFile: PactFile = {
     consumer: { name: consumer },
     provider: { name: provider },
-    interactions: matches.map(match => ({
+    interactions: matches.map((match) => ({
       description: match.request.id,
-      providerState: '',
+      providerState: "",
       request: {
         method: match.request.method,
         path: match.request.url.pathname,
         headers: headers?.excludeHeaders
-          ? omit(Object.fromEntries(match.request.headers.entries()), headers.excludeHeaders)
+          ? omit(
+              Object.fromEntries(match.request.headers.entries()),
+              headers.excludeHeaders
+            )
           : Object.fromEntries(match.request.headers.entries()),
         body: match.request.body || undefined,
-        query: match.request.url.search ? match.request.url.search.split('?')[1] : undefined
+        query: match.request.url.search
+          ? match.request.url.search.split("?")[1]
+          : undefined,
       },
       response: {
         status: match.response.status,
@@ -35,15 +41,19 @@ export const convertMswMatchToPact = ({
             )
           : Object.fromEntries(match.response.headers.entries()),
         body: match.body
-          ? match.response.headers.get('content-type')?.includes('json')
+          ? match.response.headers.get("content-type")?.includes("json")
             ? JSON.parse(match.body)
             : match.body
-          : undefined
-      }
+          : undefined,
+      },
     })),
     metadata: {
       pactSpecification: {
         version: "2.0.0",
+      },
+      client: {
+        name: "pact-msw-adapter",
+        version: pjson.version,
       },
     },
   };

--- a/src/pactFromMswServer.msw.spec.ts
+++ b/src/pactFromMswServer.msw.spec.ts
@@ -2,6 +2,7 @@ import API from "../examples/react/src/api";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { PactFile, setupPactMswAdapter } from "./pactMswAdapter";
+const pjson = require("../package.json");
 
 const server = setupServer();
 const pactMswAdapter = setupPactMswAdapter({
@@ -9,13 +10,13 @@ const pactMswAdapter = setupPactMswAdapter({
   options: {
     consumer: "testConsumer",
     providers: {
-      ['testProvider']: ['products'],
-      ['testProvider2']: ['/product/10'],
+      ["testProvider"]: ["products"],
+      ["testProvider2"]: ["/product/10"],
     },
     debug: true,
-    includeUrl: ['products', '/product'],
-    excludeUrl: ['/product/11'],
-    excludeHeaders: ["x-powered-by","cookie"]
+    includeUrl: ["products", "/product"],
+    excludeUrl: ["/product/11"],
+    excludeHeaders: ["x-powered-by", "cookie"],
   },
 });
 
@@ -59,14 +60,14 @@ describe("API - With MSW mock generating a pact", () => {
 
   test("post product ID 10", async () => {
     const productData = {
-      "type": "CREDIT_CARD",
-      "name": "28 Degrees",
+      type: "CREDIT_CARD",
+      name: "28 Degrees",
     };
-     server.use(
-       rest.post(API.url + "/product/10", (req, res, ctx) => {
-         return res(ctx.status(200), ctx.json(productData));
-       })
-     );
+    server.use(
+      rest.post(API.url + "/product/10", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(productData));
+      })
+    );
 
     const respProduct = await API.postProduct("10", productData);
     expect(respProduct).toEqual(productData);
@@ -92,22 +93,23 @@ describe("API - With MSW mock generating a pact", () => {
     const product = {
       id: "10",
       type: "CREDIT_CARD",
-      name: "28 Degrees"
+      name: "28 Degrees",
     };
     const hiddenVisibilityProduct = {
       ...product,
-      visibility: "hidden"
+      visibility: "hidden",
     };
     server.use(
       rest.get(API.url + "/product/10", (req, res, ctx) => {
-        const visibility = req.url.searchParams.get('visibility');
-        const response = visibility === 'hidden' ? hiddenVisibilityProduct : product;
+        const visibility = req.url.searchParams.get("visibility");
+        const response =
+          visibility === "hidden" ? hiddenVisibilityProduct : product;
 
         return res(ctx.status(200), ctx.json(response));
       })
     );
 
-    const respProduct = await API.getProduct("10", {visibility: "hidden"});
+    const respProduct = await API.getProduct("10", { visibility: "hidden" });
     expect(respProduct).toEqual(hiddenVisibilityProduct);
   });
 
@@ -118,41 +120,47 @@ describe("API - With MSW mock generating a pact", () => {
   });
 
   test("creates pact files", async () => {
-    let pactResults: PactFile[] = []
-    await pactMswAdapter.writeToFile((path, data) => { pactResults.push(data as PactFile) }); // writes the pacts to a file
-    expect(pactResults.length).toEqual(2)
-    expect(pactResults[0].consumer.name).toEqual('testConsumer')
-    expect(pactResults[0].provider.name).toEqual('testProvider')
-    expect(pactResults[1].consumer.name).toEqual('testConsumer')
-    expect(pactResults[1].provider.name).toEqual('testProvider2')
-    expect(pactResults[0].interactions[0].request.method).toEqual('GET')
-    expect(pactResults[0].interactions[0].request.path).toEqual('/products')
+    let pactResults: PactFile[] = [];
+    await pactMswAdapter.writeToFile((path, data) => {
+      pactResults.push(data as PactFile);
+    }); // writes the pacts to a file
+    expect(pactResults.length).toEqual(2);
+    expect(pactResults[0].consumer.name).toEqual("testConsumer");
+    expect(pactResults[0].provider.name).toEqual("testProvider");
+    expect(pactResults[1].consumer.name).toEqual("testConsumer");
+    expect(pactResults[1].provider.name).toEqual("testProvider2");
+    expect(pactResults[0].interactions[0].request.method).toEqual("GET");
+    expect(pactResults[0].interactions[0].request.path).toEqual("/products");
     expect(pactResults[0].interactions[0].request.headers).toEqual({
-      "accept": "application/json, text/plain, */*",
-      "authorization": expect.any(String) ,
+      accept: "application/json, text/plain, */*",
+      authorization: expect.any(String),
       "user-agent": expect.any(String),
-    })
-    expect(pactResults[0].interactions[0].response.status).toEqual(200)
+    });
+    expect(pactResults[0].interactions[0].response.status).toEqual(200);
 
     expect(pactResults[0].interactions[0].response.headers).toEqual({
-      "content-type": "application/json"
-    })
+      "content-type": "application/json",
+    });
     expect(pactResults[0].interactions[0].response.body).toEqual([
       {
-        "id": "09",
-        "type": "CREDIT_CARD",
-        "name": "Gem Visa"
-      }
-    ])
+        id: "09",
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+      },
+    ]);
     expect(pactResults[1].interactions[0].request.body).toEqual({
-      "type": "CREDIT_CARD",
-      "name": "28 Degrees"
-    })
-    expect(pactResults[1].interactions[1].request.body).toBeUndefined()
+      type: "CREDIT_CARD",
+      name: "28 Degrees",
+    });
+    expect(pactResults[1].interactions[1].request.body).toBeUndefined();
     expect(pactResults[0].metadata).toEqual({
-      "pactSpecification": {
-        "version": "2.0.0"
-      }
-    })
-  })
+      pactSpecification: {
+        version: "2.0.0",
+      },
+      client: {
+        name: "pact-msw-adapter",
+        version: pjson.version,
+      },
+    });
+  });
 });


### PR DESCRIPTION
As per https://docs.pactflow.io/docs/bi-directional-contract-testing/contracts/pact#converting-mocks-into-a-pact-compatible-format

adds `metadata.client` into the generated pact file