### PR TITLE
fix: Remove timestamp from pact contract file name

### DIFF
--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -270,11 +270,7 @@ export const setupPactMswAdapter = ({
         const filePath =
           options.pactOutDir +
           "/" +
-          [
-            pactFile.consumer.name,
-            pactFile.provider.name,
-            Date.now().toString(),
-          ].join("-") +
+          [pactFile.consumer.name, pactFile.provider.name].join("-") +
           ".json";
         writer(filePath, pactFile);
       });


### PR DESCRIPTION
<!-- Thank you for making a pull request! -->

<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [ ] `yarn run dist:ci` passes on my machine
- [ ] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

<!-- _Please describe what this PR is for, or link the issue that this PR fixes_ -->

<!-- _You may add as much or as little context as you like here, whatever you think is right_ -->

<!-- _Thanks again!_ -->

Refer to [this issue](https://github.com/pactflow/pact-msw-adapter/issues/56)

In short, at the moment, pact contract file name is generated in this format `consumerName-providerName-currentTime` and `currentTime` is causing a new pact file being created every time the pact tests are ran instead of updating the existing one. This PR remove the `currentTime` to fix this issue
