### PR TITLE
feat: Add option to set logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Let's start by listing it's methods:
 | excludeUrl | `false` | `string[]` | | exclusive filters for network calls |
 | excludeHeaders | `false` | `string[]` | | exclude generated headers from being written to request/response objects in pact file |
 | debug | `false` | `boolean` | `false` | prints verbose information about pact-msw-adapter events |
+| logger | `false` | `console` | `console` | logger used to print messages to console |
 
 ## Route filtering
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,36 +1,39 @@
-import { PactMswAdapterOptions } from "../pactMswAdapter";
+import { PactMswAdapterOptionsInternal } from "../pactMswAdapter";
 var path = require("path");
 let fs: any; // dynamic import
 
 const logPrefix = '[pact-msw-adapter]';
 const logColors = {
-  log: 'forestgreen',
-  warning: 'gold',
+  debug: 'gray',
+  info: 'forestgreen',
+  warn: 'gold',
   error: 'coral'
 };
 
-const log = (message: any, options?: { group?: boolean, mode?: 'log' | 'warning' | 'error' }) => {
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+export type Logger = Pick<typeof console, LogLevel | 'groupEnd' | 'groupCollapsed'>
+
+const log = (message: any, options: { group?: boolean, mode?: LogLevel, logger: Logger }) => {
   const group = options?.group || false;
-  const mode = options?.mode || 'log';
+  const mode = options?.mode || 'info';
   const color = logColors[mode];
 
-  const logFunction = group ? console.groupCollapsed : console.log;
+  const logFunction = group ? options.logger.groupCollapsed : options.logger[mode];
   logFunction(`%c${logPrefix} %c${message}`, `color:${color}`, 'color:inherit');
 }
 
-const warning = (message: any) => log(message, { mode: 'warning' });
-const logGroup = (message: any | any[], options?: { endGroup?: boolean }) => {
+const logGroup = (message: any | any[], options: { endGroup?: boolean; mode?: LogLevel; logger: Logger }) => {
   const isArray = message instanceof Array;
   if (isArray) {
     const [label, ...content] = message;
-    log(label, { group: true });
-    content.forEach((c: any) => console.log(c));
+    log(label, { group: true, mode: options.mode, logger: options.logger });
+    content.forEach((c: any) => options.logger[options?.mode || 'info'](c));
   } else {
-    log(message, { group: true });
+    log(message, { group: true, mode: options.mode, logger: options.logger });
   }
 
   if (options?.endGroup) {
-    console.groupEnd();
+    options.logger.groupEnd();
   }
 }
 
@@ -42,31 +45,31 @@ const ensureDirExists = (filePath: string) => {
   fs.mkdirSync?.(dirname);
 };
 
-const writeData2File = (filePath: string, data: Object) => {
+const createWriter = (options: PactMswAdapterOptionsInternal) => (filePath: string, data: Object) => {
   if (!fs) {
     try {
       fs = require('fs');
     } catch (e) {}
   }
   if (!fs?.existsSync) {
-    log('You need a node environment to save files.', { mode: 'warning', group: true });
-    console.log('filePath:', filePath);
-    console.log('contents:', data);
-    console.groupEnd();
+    log('You need a node environment to save files.', { mode: 'warn', group: true, logger: options.logger });
+    options.logger.info('filePath:', filePath);
+    options.logger.info('contents:', data);
+    options.logger.groupEnd();
   } else {
     ensureDirExists(filePath);
     fs.writeFileSync?.(filePath, JSON.stringify(data));
   }
 };
 
-const checkUrlFilters = (urlString: string, options: PactMswAdapterOptions) => {
+const checkUrlFilters = (urlString: string, options: PactMswAdapterOptionsInternal) => {
   const providerFilter = Object.values(options.providers)
     ?.some(validPaths => validPaths.some(path => urlString.includes(path)));
   const includeFilter = !options.includeUrl || options.includeUrl.some(inc => urlString.includes(inc));
   const excludeFilter = !options.excludeUrl || !options.excludeUrl.some(exc => urlString.includes(exc));
   const matchIsAllowed = includeFilter && excludeFilter && providerFilter
   if (options.debug) {
-    logGroup(['Checking request against url filters', { urlString, providerFilter, includeFilter, excludeFilter, matchIsAllowed }]);
+    logGroup(['Checking request against url filters', { urlString, providerFilter, includeFilter, excludeFilter, matchIsAllowed }], { logger: options.logger });
   }
 
   return matchIsAllowed;
@@ -82,4 +85,4 @@ const addTimeout = async<T>(promise: Promise<T>, label: string, timeout: number)
   return Promise.race([promise, asyncTimeout]);
 }
 
-export { log, warning, logGroup, writeData2File, checkUrlFilters, addTimeout };
+export { log, logGroup, createWriter, checkUrlFilters, addTimeout };


### PR DESCRIPTION
### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

Fixes: https://github.com/pactflow/pact-msw-adapter/issues/58

Adds option to pass logger into `setupPactMswAdapter` to give user control about what and how is being logged. Defaults to `console` for all users that don't pass it in. The interface is intentionally minimal yet powerful and allows many use-cases like log level control, prefixes, formatting, ...

note: I tried to make the changes as minimal and consistent with current codebase as possible. If you feel this should go different direction please let me know.