### PR TITLE
feat: Allow dynamic provider matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Let's start by listing it's methods:
 | worker  | false     | `SetupWorkerApi` |  | worker provided by msw - a server or worker must be provided|
 | timeout | `false` | `number` | 200 | Time in ms for a network request to expire, `verifyTest` will fail after twice this amount of time. |
 | consumer | `true` | `string` | | name of the consumer running the tests |
-| providers | `true` | `{ [string]: string[] }` | | names and filters for each provider |
+| providers | `true` | `{ [string]: string[] } | (request: MockedRequest) => string | null` | | names and filters for each provider or function that returns name of provider for given request |
 | pactOutDir | `false` | `string` | ./msw_generated_pacts/ | path to write pact files into |
 | includeUrl | `false` | `string[]` | | inclusive filters for network calls |
 | excludeUrl | `false` | `string[]` | | exclusive filters for network calls |
@@ -69,6 +69,8 @@ This mechanism has three layers, in order of priority:
 - `providers`: Paths not containing any of the strings listed in the map’s values will be ignored.
 
 The first two layers can be skipped by setting it’s value to `undefined`. The third layer is mandatory.
+
+`providers` can be also a function that returns name of provider for given request. If no provider is matched it should return `null`. This allows dynamically matching providers based on url patterns.
 
 ## Header filtering
 


### PR DESCRIPTION
### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

It's common in larger systems that URLs follow certain patterns. This PR adds ability to pass a function into provider which allows user to implement any such pattern for matching providers.

for example when provider is first segment of pathname user can match it like this
```ts
setupPactMswAdapter({
  options: {
    providers: (req) => {
       return req.url.pathname.match(/\/([\w\d]+)\/.*/) ?? null
    }
  }
  // ...
})
```

