### PR TITLE
Deps/node engines gteq16

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,67 +7,12 @@ on:
 
 jobs:
 
-  build-and-test-osx:
-    runs-on: macos-latest
+  build-and-test:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn install
-        shell: bash
-      - run: yarn run dist:ci
-        shell: bash
-      - run: yarn link
-        shell: bash
-      - run: yarn run example:link
-        shell: bash
-      - run: yarn run example:install
-        shell: bash
-      - run: yarn run example:test:unit
-        shell: bash
-      - run: yarn run example:test:cy:run
-        shell: bash
-
-  build-and-test-ubuntu:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x, 18.x]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn install
-        shell: bash
-      - run: yarn run dist:ci
-        shell: bash
-      - run: yarn link
-        shell: bash
-      - run: yarn run example:link
-        shell: bash
-      - run: yarn run example:install
-        shell: bash
-      - run: yarn run example:test:unit
-        shell: bash
-      - run: yarn run example:test:cy:run
-        shell: bash
-
-  build-and-test-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x, 18.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        node-version: [16.x, 18.x, 19.x, 20.x]
       fail-fast: false
 
     steps:

--- a/examples/react/src/api.js
+++ b/examples/react/src/api.js
@@ -36,14 +36,23 @@ export class API {
     }
 
     async getProduct(id, params) {
-        return axios.get(this.withPath("/product/" + id), {
-            params,
-            headers: {
-                "Authorization": this.generateAuthToken()
-            }
-        })
-            .then(r => r.data);
-    }
+        try {
+          return await axios
+            .get(this.withPath('/product/' + id), {
+              params,
+              headers: {
+                Authorization: this.generateAuthToken()
+              }
+            })
+            .then((r) => r.data);
+        } catch (error) {
+          if (error.errors && error.errors.length > 0) {
+            return Promise.reject(new Error(error.errors));
+          } else {
+            return Promise.reject(new Error(error));
+          }
+        }
+      }
 
     async postProduct(id, productData) {
         return await axios.post(this.withPath("/product/" + id), productData, {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "msw": ">=0.35.0"
+    "msw": ">=0.36.9"
   },
   "engines": {
     "node": ">=16"
@@ -49,7 +49,7 @@
     "@types/jest": "27.4.1",
     "@typescript-eslint/eslint-plugin": "5.56.0",
     "@typescript-eslint/parser": "5.59.5",
-    "axios": "0.26.0",
+    "axios": "0.26.1",
     "babel-jest": "27.5.1",
     "eslint": "8.10.0",
     "jest": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "peerDependencies": {
     "msw": ">=0.35.0"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",

--- a/src/pactFromMswServer.msw.spec.ts
+++ b/src/pactFromMswServer.msw.spec.ts
@@ -115,7 +115,7 @@ describe("API - With MSW mock generating a pact", () => {
 
   test("unhandled route", async () => {
     await expect(API.getProduct("11")).rejects.toThrow(
-      /^connect ECONNREFUSED (127.0.0.1|::1):8081$/
+      /^Error: connect ECONNREFUSED (127.0.0.1|::1):8081.*$/
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,10 +1870,10 @@ axios@*:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
-axios@0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
-  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
+axios@0.26.1:
+  version "0.26.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
 


### PR DESCRIPTION
# Dropping support for Node versions below 16 in our project. 

## Why

- Active development of Node 14 ended 21 Apr 2020
  - Active support of Node 14 ended 19 Oct 2021
  - Security support of Node 14 ended 30 Apr 2023
  
- Active development of Node 16 ended 20 Apr 2021
  - Active support of Node 16 ended 18 Oct 2022
  - Security support of Node 16 will end 11 Sep 2023 ( 3 months & 3 weeks at time of writing)

### Main problems of supporting EOL versions

- **Outdated code:** Supporting older versions may lead to the use of outdated and less optimal solutions.
- **Increased development and debugging time:** Supporting older versions requires extra effort as we need to take into account the peculiarities of each supported version.
- **Library compatibility issues:** Many modern libraries no longer support older versions, which may create difficulties in their usage and integration.
- **Missing new features:** Older versions do not support some of the new features and improvements that have been introduced in more recent versions
- **Decreased performance:** Supporting older versions may reduce the project's performance as some optimizations are only available in newer versions.
- - **Complicated testing:** No available CI hardware to test against Maintaining (including tricks with CI/CD, Docker support, and local testing) across exotic versions requires more time and resources.

## Actions 

Considering the aforementioned problems, it is recommended to drop support for versions from testing in our CI systems, for any versions out of security support

We use the following reference site https://endoflife.date


## Tested Platforms

We attempt to be tested cross-platform/architecture, across multiple versions. See the
following table for progress.

### Legend

- ✅ : Automated testing in CI
- 🚧 : Awaiting CI/CD build with Cirrus-CI
- 👷🏽 : No available CI hardware to test against

### Testing Matrix

Architechture            | Version     | Windows      | Linux     | macOS  | 
-------------------- | ----------|------------- | -------- | ------   |
x86_64 (AMD64)     | 14.x           | ✅          | ✅     | ✅      |  ✅        | 
x86_64 (AMD64)     | 16.x           | ✅          | ✅     | ✅      | ✅         | 
x86_64 (AMD64)     | 18.x           | ✅          | ✅     | ✅      | ✅         |  
x86_64 (AMD64)     | 20.x           | ✅          | ✅     | ✅      | ✅        |  
AArch64 (ARM64)   | 14.x           | 👷🏽          | 🚧     | 🚧       | 🚧       |  
AArch64 (ARM64)   | 16.x           | 👷🏽          | 🚧     | 🚧       | 🚧       |  
AArch64 (ARM64)   | 18.x           | 👷🏽          | 🚧     | 🚧       | 🚧       |  
AArch64 (ARM64)   | 20.x           | 👷🏽          | 🚧     | 🚧       | 🚧       |  


## Notifying users

- Update node_engines field to set to
   
      "engines": {
        "node": ">=16"
      },

- Update testing matrix, to drop node 14

- Add badges to `README`, to notify user

[![GitHub release](https://img.shields.io/github/release/pactflow/pact-msw-adapter)](https://github.com/pactflow/pact-msw-adapter)
[![Npm package license](https://badgen.net/npm/license/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)
[![Npm package version](https://badgen.net/npm/v/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)
[![Minimum node.js version](https://badgen.net/npm/node/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)

[![Npm package total downloads](https://badgen.net/npm/dt/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)
[![Npm package yearly downloads](https://badgen.net/npm/dy/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)
[![Npm package monthly downloads](https://badgen.net/npm/dm/@pactflow/pact-msw-adapter)](https://npmjs.ccom/package/@pactflow/pact-msw-adapter)
[![Npm package daily downloads](https://badgen.net/npm/dd/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)
[![Npm package dependents](https://badgen.net/npm/dependents/@pactflow/pact-msw-adapter)](https://npmjs.com/package/@pactflow/pact-msw-adapter)

[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/pact-foundation/pact-msw-adapter/graphs/commit-activity)
[![Build and test](https://github.com/pactflow/pact-msw-adapter/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/pactflow/pact-msw-adapter/actions/workflows/build-and-test.yml)
[![Publish and release](https://github.com/pactflow/pact-msw-adapter/actions/workflows/publish.yml/badge.svg)](https://github.com/pactflow/pact-msw-adapter/actions/workflows/publish.yml)
[![Linux](https://svgshare.com/i/Zhy.svg)](https://svgshare.com/i/Zhy.svg)
[![macOS](https://svgshare.com/i/ZjP.svg)](https://svgshare.com/i/ZjP.svg)
[![Windows](https://svgshare.com/i/ZhY.svg)](https://svgshare.com/i/ZhY.svg)

