### PR TITLE
Clear timeout if promise has already resolves to avoid hanging open handle

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -85,13 +85,14 @@ const checkUrlFilters = (request: MockedRequest, options: PactMswAdapterOptionsI
 };
 
 const addTimeout = async<T>(promise: Promise<T>, label: string, timeout: number) => {
+  let timeoutId: NodeJS.Timeout
   const asyncTimeout = new Promise<void>((_, reject) => {
-    setTimeout(() => {
+    timeoutId = setTimeout(() => {
       reject(new Error(`[pact-msw-adapter] ${label} timed out after ${timeout}ms`));
     }, timeout);
   });
 
-  return Promise.race([promise, asyncTimeout]);
+  return Promise.race([promise, asyncTimeout]).then(() => clearTimeout(timeoutId));
 }
 
 export { log, logGroup, createWriter, checkUrlFilters, addTimeout };


### PR DESCRIPTION
<!-- Thank you for making a pull request! -->

<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

<!-- _Please describe what this PR is for, or link the issue that this PR fixes_ -->

<!-- _You may add as much or as little context as you like here, whatever you think is right_ -->

<!-- _Thanks again!_ -->

We are getting error from jest when running it with `--detectOpenHandles` 
![image](https://github.com/pactflow/pact-msw-adapter/assets/23372284/436e9e45-d6e8-49d7-9c99-86f31bc9db48)

Atm, the `addTimeout` is not clearing the timeout when the `promise` has resolved which is causing this issue
