### PR TITLE
fix: unref asyncTimeout; fixes open handle issue in jest

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -88,7 +88,7 @@ const addTimeout = async<T>(promise: Promise<T>, label: string, timeout: number)
   const asyncTimeout = new Promise<void>((_, reject) => {
     setTimeout(() => {
       reject(new Error(`[pact-msw-adapter] ${label} timed out after ${timeout}ms`));
-    }, timeout);
+    }, timeout).unref();
   });
 
   return Promise.race([promise, asyncTimeout]);


### PR DESCRIPTION
<!-- Thank you for making a pull request! -->

<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

When running our jest unit tests, they always end with this "Jest did not exit one second after the test run has completed" message:
<img width="800" alt="jestDidNotExitOneSecond" src="https://github.com/pactflow/pact-msw-adapter/assets/961776/b7dba4a9-4b4b-49a4-9735-d932dade8a17">

Adding `.unref()` to the `setTimeout()` fixes this issue.

Jest recommends calling `.unref()` on any timers used in your tests to fix open handles like this.

**Note:** This is a similar fix to the following pull request: https://github.com/pactflow/pact-msw-adapter/pull/123
So only one of them should be merged.
