### PR TITLE
Allow parsing matchers from response body

### DIFF
--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -1,13 +1,15 @@
 import { PactFile, MatchedRequest } from "./pactMswAdapter";
 import { omit } from "lodash";
 import { JSONValue } from "./utils/utils";
+// const { MatchersV3 } = require("@pact-foundation/pact");
+import { MatchersV3 } from "@pact-foundation/pact";
 const pjson = require("../package.json");
 
 export const readBody = async (input: Request | Response) => {
   // so we don't reread body somewhere
   const clone = input.clone();
 
-  if (clone.body === null) return undefined
+  if (clone.body === null) return undefined;
 
   const contentType = clone.headers.get("content-type");
   if (contentType?.startsWith("application/json")) {
@@ -18,7 +20,97 @@ export const readBody = async (input: Request | Response) => {
 
   // default to text
   return clone.text();
-}
+};
+
+const serialiseResponseObject = (key: string, value: unknown): object => {
+  if (MatchersV3.isMatcher(value)) {
+    return {
+      [key]: value.value,
+    };
+  }
+
+  if (value === null) {
+    return { [key]: "" };
+  }
+
+  if (Array.isArray(value)) {
+    const serialisedArray = value.map((item) => serialiseResponse(item));
+    return { [key]: serialisedArray };
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const fields = Object.entries(value);
+    const serialisedFields = fields.reduce((acc, [fieldKey, fieldValue]) => {
+      return {
+        ...acc,
+        ...serialiseResponseObject(fieldKey, fieldValue),
+      };
+    }, {});
+    return { [key]: serialisedFields };
+  }
+
+  return { [key]: value };
+};
+
+const serialiseResponse = (field: unknown): object | undefined => {
+  if (MatchersV3.isMatcher(field)) {
+    return serialiseResponse(field.value);
+  }
+
+  if (field === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(field)) {
+    return field.map((item) => serialiseResponse(item));
+  }
+
+  if (typeof field === "object") {
+    const fields = Object.entries(field);
+    const serialisedFields = fields.reduce((acc, [fieldKey, fieldValue]) => {
+      return {
+        ...acc,
+        ...serialiseResponseObject(fieldKey, fieldValue),
+      };
+    }, {});
+    return serialisedFields;
+  }
+
+  return field;
+};
+
+const buildMatchingRules = (
+  field: unknown,
+  path: string = "$"
+): object | undefined => {
+  let matchingRules: any = {};
+
+  if (MatchersV3.isMatcher(field)) {
+    matchingRules[path] = {
+      combine: "AND",
+      matchers: [
+        {
+          match: field["pact:matcher:type"],
+          // @ts-expect-error - TS doesn't know about the `regex` field
+          regex: field?.regex || undefined,
+        },
+      ],
+    };
+  } else if (field !== null && typeof field === "object") {
+    // Traverse the object to find nested matchers
+    Object.entries(field).forEach(([key, value]) => {
+      const newPath = `${path}.${key}`;
+      const nestedMatchingRules = buildMatchingRules(value, newPath);
+      matchingRules = { ...matchingRules, ...nestedMatchingRules };
+    });
+  }
+
+  return matchingRules;
+};
+
+const hasMatchers = (field: unknown): boolean => {
+  return JSON.stringify(field).includes("pact:matcher:type");
+};
 
 export const convertMswMatchToPact = async ({
   consumer,
@@ -34,28 +126,39 @@ export const convertMswMatchToPact = async ({
   const pactFile: PactFile = {
     consumer: { name: consumer },
     provider: { name: provider },
-    interactions: await Promise.all(matches.map(async (match) => ({
-      description: match.requestId,
-      providerState: "",
-      request: {
-        method: match.request.method,
-        path: new URL(match.request.url).pathname,
-        headers: omit(
-          Object.fromEntries(match.request.headers.entries()),
-          headers?.excludeHeaders ?? []
-        ),
-        body: await readBody(match.request),
-        query: new URL(match.request.url).search?.split("?")[1]
-      },
-      response: {
-        status: match.response.status,
-        headers: omit(
-          Object.fromEntries(match.response.headers.entries()),
-          headers?.excludeHeaders ?? []
-        ),
-        body: await readBody(match.response),
-      },
-    }))),
+    interactions: await Promise.all(
+      matches.map(async (match) => {
+        const body = serialiseResponse(await readBody(match.response));
+
+        return {
+          description: match.requestId,
+          providerState: "",
+          request: {
+            method: match.request.method,
+            path: new URL(match.request.url).pathname,
+            headers: omit(
+              Object.fromEntries(match.request.headers.entries()),
+              headers?.excludeHeaders ?? []
+            ),
+            body: await readBody(match.request),
+            query: new URL(match.request.url).search?.split("?")[1],
+          },
+          response: {
+            status: match.response.status,
+            headers: omit(
+              Object.fromEntries(match.response.headers.entries()),
+              headers?.excludeHeaders ?? []
+            ),
+            body,
+            matchingRules: hasMatchers(await readBody(match.response))
+              ? {
+                  body: buildMatchingRules(await readBody(match.response)),
+                }
+              : undefined,
+          },
+        };
+      })
+    ),
     metadata: {
       pactSpecification: {
         version: "2.0.0",

--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -115,7 +115,11 @@ const buildMatchingRules = (
   // }else{
   if (typeof field !== "object") {
     matchingRules[path] = {
-      match: "type",
+      matchers: [
+        {
+          match: "type",
+        },
+      ],
     };
   }
   // }
@@ -128,11 +132,13 @@ export const convertMswMatchToPact = async ({
   provider,
   matches,
   headers,
+  options,
 }: {
   consumer: string;
   provider: string;
   matches: MatchedRequest[];
-  headers?: { excludeHeaders: string[] | undefined; useFuzzyMatchers: boolean };
+  headers?: { excludeHeaders: string[] | undefined };
+  options?: { useFuzzyMatchers: boolean; pactVersion: string };
 }): Promise<PactFile> => {
   const pactFile: PactFile = {
     consumer: { name: consumer },
@@ -159,9 +165,11 @@ export const convertMswMatchToPact = async ({
               headers?.excludeHeaders ?? []
             ),
             body: await readBody(match.response),
-            matchingRules: headers?.useFuzzyMatchers
+            matchingRules: options?.useFuzzyMatchers
               ? {
                   body: buildMatchingRules(await readBody(match.response)),
+                  header: {},
+                  status: {},
                 }
               : undefined,
           },
@@ -170,7 +178,7 @@ export const convertMswMatchToPact = async ({
     ),
     metadata: {
       pactSpecification: {
-        version: "2.0.0",
+        version: options?.pactVersion || "2.0.0",
       },
       client: {
         name: "pact-msw-adapter",

--- a/src/pactFromMswServerWithMatchers.msw.spec.ts
+++ b/src/pactFromMswServerWithMatchers.msw.spec.ts
@@ -17,6 +17,7 @@ const pactMswAdapter = setupPactMswAdapter({
     includeUrl: ["products", "/product"],
     excludeUrl: ["/product/11"],
     excludeHeaders: ["x-powered-by", "cookie", "accept-encoding", "host"],
+    useFuzzyMatchers: true,
   },
 });
 
@@ -45,7 +46,7 @@ describe("API - With MSW mock generating matchers", () => {
   describe("'like' matcher", () => {
     test("generates a contract with the matcher at the top level", async () => {
       const product = {
-        id: MatchersV3.like("10"),
+        id: "10",
         type: "CREDIT_CARD",
         name: "Gem Visa",
       };
@@ -56,7 +57,11 @@ describe("API - With MSW mock generating matchers", () => {
       );
 
       const respProduct = await API.getProduct("10");
-      expect(respProduct).toEqual(product);
+      expect(respProduct).toEqual({
+        id: "10",
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+      });
 
       await pactMswAdapter.writeToFile((path, data) => {
         pactResults.push(data as PactFile);
@@ -70,12 +75,13 @@ describe("API - With MSW mock generating matchers", () => {
       expect(pactResults[0].interactions[0].response.matchingRules).toEqual({
         body: {
           "$.id": {
-            combine: "AND",
-            matchers: [
-              {
-                match: "type",
-              },
-            ],
+            match: "type",
+          },
+          "$.type": {
+            match: "type",
+          },
+          "$.name": {
+            match: "type",
           },
         },
       });
@@ -83,11 +89,11 @@ describe("API - With MSW mock generating matchers", () => {
 
     test("generates a contract with the matcher nested", async () => {
       const product = {
-        id: MatchersV3.like("10"),
+        id: "10",
         type: "CREDIT_CARD",
         name: "Gem Visa",
         category: {
-          type: MatchersV3.like("Food"),
+          type: "Food",
         },
       };
 
@@ -98,37 +104,40 @@ describe("API - With MSW mock generating matchers", () => {
       );
 
       const respProduct = await API.getProduct("10");
-      expect(respProduct).toEqual(product);
+      expect(respProduct).toEqual({
+        id: "10",
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+        category: {
+          type: "Food",
+        },
+      });
 
       await pactMswAdapter.writeToFile((path, data) => {
         pactResults.push(data as PactFile);
       });
 
-      expect(pactResults[0].interactions[0].response.body).toStrictEqual({
-        category: {
-          type: "Food",
-        },
+      expect(pactResults[0].interactions[0].response.body).toEqual({
         id: "10",
         type: "CREDIT_CARD",
         name: "Gem Visa",
+        category: {
+          type: "Food",
+        },
       });
       expect(pactResults[0].interactions[0].response.matchingRules).toEqual({
         body: {
           "$.id": {
-            combine: "AND",
-            matchers: [
-              {
-                match: "type",
-              },
-            ],
+            match: "type",
+          },
+          "$.type": {
+            match: "type",
+          },
+          "$.name": {
+            match: "type",
           },
           "$.category.type": {
-            combine: "AND",
-            matchers: [
-              {
-                match: "type",
-              },
-            ],
+            match: "type",
           },
         },
       });

--- a/src/pactFromMswServerWithMatchers.msw.spec.ts
+++ b/src/pactFromMswServerWithMatchers.msw.spec.ts
@@ -1,0 +1,137 @@
+import API from "../examples/react/src/api";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { PactFile, setupPactMswAdapter } from "./pactMswAdapter";
+import { MatchersV3 } from "@pact-foundation/pact";
+
+const server = setupServer();
+const pactMswAdapter = setupPactMswAdapter({
+  server,
+  options: {
+    consumer: "testConsumerWithMatchers",
+    providers: {
+      ["testProvider"]: ["products"],
+      ["testProvider2"]: ["/product/10"],
+    },
+    debug: true,
+    includeUrl: ["products", "/product"],
+    excludeUrl: ["/product/11"],
+    excludeHeaders: ["x-powered-by", "cookie", "accept-encoding", "host"],
+  },
+});
+
+describe("API - With MSW mock generating matchers", () => {
+  let pactResults: PactFile[] = [];
+
+  beforeAll(async () => {
+    server.listen();
+  });
+
+  beforeEach(async () => {
+    pactMswAdapter.newTest();
+    pactResults = [];
+  });
+
+  afterEach(async () => {
+    pactMswAdapter.verifyTest();
+    server.resetHandlers();
+    pactMswAdapter.clear();
+  });
+
+  afterAll(async () => {
+    server.close();
+  });
+
+  describe("'like' matcher", () => {
+    test("generates a contract with the matcher at the top level", async () => {
+      const product = {
+        id: MatchersV3.like("10"),
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+      };
+      server.use(
+        http.get(API.url + "/product/10", () => {
+          return HttpResponse.json(product);
+        })
+      );
+
+      const respProduct = await API.getProduct("10");
+      expect(respProduct).toEqual(product);
+
+      await pactMswAdapter.writeToFile((path, data) => {
+        pactResults.push(data as PactFile);
+      });
+
+      expect(pactResults[0].interactions[0].response.body).toEqual({
+        id: "10",
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+      });
+      expect(pactResults[0].interactions[0].response.matchingRules).toEqual({
+        body: {
+          "$.id": {
+            combine: "AND",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    test("generates a contract with the matcher nested", async () => {
+      const product = {
+        id: MatchersV3.like("10"),
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+        category: {
+          type: MatchersV3.like("Food"),
+        },
+      };
+
+      server.use(
+        http.get(API.url + "/product/10", () => {
+          return HttpResponse.json(product);
+        })
+      );
+
+      const respProduct = await API.getProduct("10");
+      expect(respProduct).toEqual(product);
+
+      await pactMswAdapter.writeToFile((path, data) => {
+        pactResults.push(data as PactFile);
+      });
+
+      expect(pactResults[0].interactions[0].response.body).toStrictEqual({
+        category: {
+          type: "Food",
+        },
+        id: "10",
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
+      });
+      expect(pactResults[0].interactions[0].response.matchingRules).toEqual({
+        body: {
+          "$.id": {
+            combine: "AND",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
+          },
+          "$.category.type": {
+            combine: "AND",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/pactFromMswServerWithMatchers.msw.spec.ts
+++ b/src/pactFromMswServerWithMatchers.msw.spec.ts
@@ -75,15 +75,29 @@ describe("API - With MSW mock generating matchers", () => {
       expect(pactResults[0].interactions[0].response.matchingRules).toEqual({
         body: {
           "$.id": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
           "$.type": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
           "$.name": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
         },
+        header: {},
+        status: {},
       });
     });
 
@@ -118,28 +132,46 @@ describe("API - With MSW mock generating matchers", () => {
       });
 
       expect(pactResults[0].interactions[0].response.body).toEqual({
-        id: "10",
-        type: "CREDIT_CARD",
-        name: "Gem Visa",
         category: {
           type: "Food",
         },
+        id: "10",
+        type: "CREDIT_CARD",
+        name: "Gem Visa",
       });
       expect(pactResults[0].interactions[0].response.matchingRules).toEqual({
         body: {
           "$.id": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
           "$.type": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
           "$.name": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
           "$.category.type": {
-            match: "type",
+            matchers: [
+              {
+                match: "type",
+              },
+            ],
           },
         },
+        header: {},
+        status: {},
       });
     });
   });

--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -23,6 +23,7 @@ export interface PactMswAdapterOptions {
   excludeUrl?: string[];
   excludeHeaders?: string[];
   logger?: Logger;
+  useFuzzyMatchers?: boolean;
 }
 export interface PactMswAdapterOptionsInternal {
   timeout: number;
@@ -36,6 +37,7 @@ export interface PactMswAdapterOptionsInternal {
   excludeUrl?: string[];
   excludeHeaders?: string[];
   logger: Logger;
+  useFuzzyMatchers: boolean;
 }
 
 export interface PactMswAdapter {
@@ -72,6 +74,7 @@ export const setupPactMswAdapter = ({
     timeout: externalOptions.timeout || 200,
     debug: externalOptions.debug || false,
     pactOutDir: externalOptions.pactOutDir || "./msw_generated_pacts/",
+    useFuzzyMatchers: externalOptions.useFuzzyMatchers || false,
   };
 
   logGroup(`Adapter enabled${options.debug ? " on debug mode" : ""}`, { logger: options.logger });
@@ -350,6 +353,7 @@ const transformMswToPact = async (
         matches: providerMatches,
         headers: {
           excludeHeaders: options.excludeHeaders,
+          useFuzzyMatchers: options.useFuzzyMatchers,
         },
       });
       if (pactFile) {

--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -16,7 +16,9 @@ export interface PactMswAdapterOptions {
   debug?: boolean;
   pactOutDir?: string;
   consumer: string;
-  providers: { [name: string]: string[] } | ((event: PendingRequest) => string | null);
+  providers:
+    | { [name: string]: string[] }
+    | ((event: PendingRequest) => string | null);
   includeUrl?: string[];
   excludeUrl?: string[];
   excludeHeaders?: string[];
@@ -27,7 +29,9 @@ export interface PactMswAdapterOptionsInternal {
   debug: boolean;
   pactOutDir: string;
   consumer: string;
-  providers: { [name: string]: string[] } | ((event: PendingRequest) => string | null);
+  providers:
+    | { [name: string]: string[] }
+    | ((event: PendingRequest) => string | null);
   includeUrl?: string[];
   excludeUrl?: string[];
   excludeHeaders?: string[];
@@ -344,7 +348,9 @@ const transformMswToPact = async (
         consumer: options.consumer,
         provider,
         matches: providerMatches,
-        headers: { excludeHeaders: options.excludeHeaders },
+        headers: {
+          excludeHeaders: options.excludeHeaders,
+        },
       });
       if (pactFile) {
         pactFiles.push(pactFile);
@@ -382,6 +388,7 @@ export interface PactInteraction {
     status: number;
     headers: any;
     body: any;
+    matchingRules?: object;
   };
 }
 

--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -24,6 +24,7 @@ export interface PactMswAdapterOptions {
   excludeHeaders?: string[];
   logger?: Logger;
   useFuzzyMatchers?: boolean;
+  pactVersion?: "2.0.0" | "3.0.0";
 }
 export interface PactMswAdapterOptionsInternal {
   timeout: number;
@@ -38,6 +39,7 @@ export interface PactMswAdapterOptionsInternal {
   excludeHeaders?: string[];
   logger: Logger;
   useFuzzyMatchers: boolean;
+  pactVersion: "2.0.0" | "3.0.0";
 }
 
 export interface PactMswAdapter {
@@ -75,6 +77,7 @@ export const setupPactMswAdapter = ({
     debug: externalOptions.debug || false,
     pactOutDir: externalOptions.pactOutDir || "./msw_generated_pacts/",
     useFuzzyMatchers: externalOptions.useFuzzyMatchers || false,
+    pactVersion: externalOptions.pactVersion || "2.0.0",
   };
 
   logGroup(`Adapter enabled${options.debug ? " on debug mode" : ""}`, { logger: options.logger });
@@ -353,7 +356,10 @@ const transformMswToPact = async (
         matches: providerMatches,
         headers: {
           excludeHeaders: options.excludeHeaders,
+        },
+        options: {
           useFuzzyMatchers: options.useFuzzyMatchers,
+          pactVersion: options.pactVersion,
         },
       });
       if (pactFile) {


### PR DESCRIPTION
<!-- Thank you for making a pull request! -->

<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

This PR adds the ability to add the `like` matcher to a response body and consume this into a valid pact contract.

This is the first step towards supporting the entire suite of Pact matchers in this library, but this should be enough to support the majority of cases where people need matchers for the time being.
