### PR TITLE
Fix/expired listener

### DIFF
--- a/src/pactFromMswServer.msw.spec.ts
+++ b/src/pactFromMswServer.msw.spec.ts
@@ -113,6 +113,15 @@ describe("API - With MSW mock generating a pact", () => {
     expect(respProduct).toEqual(hiddenVisibilityProduct);
   });
 
+  test("handle requests mocked with error", async () => {
+    server.use(
+      http.get(API.url + "/product/10", () => HttpResponse.error())
+    );
+    
+    // This request is going to be marked as expired after the test is finished and should be handled gracefully by the subsequent writeToFile()
+    await expect(()=> API.getProduct("10")).rejects.toEqual(new Error('TypeError: Network error'))
+  })
+
   test("unhandled route", async () => {
     await expect(API.getProduct("11")).rejects.toThrow(
       /^Error: connect ECONNREFUSED (127.0.0.1|::1):8081.*$/

--- a/src/pactMswAdapter.ts
+++ b/src/pactMswAdapter.ts
@@ -102,12 +102,12 @@ export const setupPactMswAdapter = ({
     setTimeout(() => {
       const expired = { requestId, startTime, request }
       const activeIdx = activeRequestIds.indexOf(requestId);
-      emitter.emit("pact-msw-adapter:expired", expired);
       if (activeIdx >= 0) {
         // Could be removed if completed or the test ended
         activeRequestIds.splice(activeIdx, 1);
         expiredRequests.push(expired);
       }
+      emitter.emit("pact-msw-adapter:expired", expired);
     }, options.timeout);
   });
 
@@ -301,7 +301,7 @@ const transformMswToPact = async (
       }
 
       const events = [
-        "pact-msw-adapter:expired ",
+        "pact-msw-adapter:expired",
         "pact-msw-adapter:match",
         "pact-msw-adapter:new-test",
         "pact-msw-adapter:clear",


### PR DESCRIPTION
### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

My team has found this issue when investigating why file writes would fail with the following message after certain tests:

![image](https://github.com/user-attachments/assets/7d49a032-4309-4d2c-b357-0df86b56f51a)

Turns out that any request that is marked as expired is causing a timeout to happen due to `requestsCompleted` never resolving. This happened mainly due two factors:
- The event name for `expired` had a trailing space, which effectively made the listener wait for a non-existent event to happen. Removing the trailing space has fixed this issue;
- The `expired` event was emitted **before** the relevant event was removed from the `activeRequestIds`, which would cause the listener to think there were still pending requests, and wait for the remaining requests to be resolved. Moving the event emitting to _after_ the removal of the request from the array has fixed this issue.

Thanks in advance!